### PR TITLE
Style/page layout tweaks

### DIFF
--- a/src/pages/article/[slug].astro
+++ b/src/pages/article/[slug].astro
@@ -51,7 +51,6 @@ const { Content, headings } = await render(article);
     min-height: 100vh;
     display: flex;
     flex-direction: row-reverse;
-    justify-content: space-between;
     align-items: flex-start;
     gap: 30px;
 
@@ -59,6 +58,12 @@ const { Content, headings } = await render(article);
     padding-inline: 50px 0;
 
     background-color: var(--bg-all);
+  }
+
+  .centering-div {
+    flex: 1;
+    display: flex;
+    justify-content: center;
   }
 
   .reading-pane {
@@ -88,14 +93,17 @@ const { Content, headings } = await render(article);
 <BaseLayout title={article.data.title}>
   <main class="wrapper">
     <TableOfContents className="hideSmall" headings={headings} />
-    <div class="reading-pane">
-      <hgroup class="title">
-        <h1>{article.data.title}</h1>
-      </hgroup>
-      <TableOfContents className="hideBig" headings={headings} />
-      <Prose>
-        <Content />
-      </Prose>
+    <div class="centering-div">
+      <div class="reading-pane">
+        <hgroup class="title">
+          <h1>{article.data.title}</h1>
+        </hgroup>
+        <TableOfContents className="hideBig" headings={headings} />
+        <Prose>
+          <Content />
+        </Prose>
+      </div>
     </div>
+
   </main>
 </BaseLayout>

--- a/src/pages/article/[slug].astro
+++ b/src/pages/article/[slug].astro
@@ -41,6 +41,10 @@ const { Content, headings } = await render(article);
     main.wrapper {
       padding: 0;
     }
+
+    div.centering-div {
+        justify-content: flex-start;
+    }
   }
 
   .wrapper {
@@ -64,6 +68,8 @@ const { Content, headings } = await render(article);
     flex: 1;
     display: flex;
     justify-content: center;
+
+    max-width: 100%;
   }
 
   .reading-pane {
@@ -76,7 +82,6 @@ const { Content, headings } = await render(article);
     background-color: var(--bg-text);
     box-shadow: 0 0 20px var(--shadow);
 
-    align-items: flex-start;
     padding: 20px;
   }
 

--- a/src/pages/article/[slug].astro
+++ b/src/pages/article/[slug].astro
@@ -39,7 +39,7 @@ const { Content, headings } = await render(article);
 
   @media (width <= 850px) {
     main.wrapper {
-      padding-right: 50px;
+      padding: 0;
     }
   }
 

--- a/src/pages/article/[slug].astro
+++ b/src/pages/article/[slug].astro
@@ -74,12 +74,24 @@ const { Content, headings } = await render(article);
     align-items: flex-start;
     padding: 20px;
   }
+
+  .title {
+    align-self: stretch;
+    text-align: center;
+    background: var(--bg-popoup);
+    padding: 10px;
+    box-shadow: 1px 1px 3px black;
+    color: var(--fg-inverted);
+  }
 </style>
 
 <BaseLayout title={article.data.title}>
   <main class="wrapper">
     <TableOfContents className="hideSmall" headings={headings} />
     <div class="reading-pane">
+      <hgroup class="title">
+        <h1>{article.data.title}</h1>
+      </hgroup>
       <TableOfContents className="hideBig" headings={headings} />
       <Prose>
         <Content />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,6 @@
 ---
 import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
-import TableOfContents from "../components/TableOfContents/TableOfContents.astro";
-import Prose from "../components/Prose.astro";
 import { BASE_URL } from "../../constants";
 
 const articles = await getCollection("articles");


### PR DESCRIPTION
But 3 things are "fixed" here:
* now we always add title in red for every page (ssimilarly to how we do "Laurasia" on index page)
* some tweaks to make the page actually work on phone / small screens
* some centering fixes for large screens

| | BEFORE | AFTER |
| --- | --- | --- |
| Heading change | <img width="1386" height="298" alt="image" src="https://github.com/user-attachments/assets/9545e2c8-4115-4f35-b880-2f88e04a514d" /> | <img width="1391" height="385" alt="image" src="https://github.com/user-attachments/assets/f5eef945-070b-460d-ae87-7f9305f2f444" /> |
| Small page fixes | <img width="544" height="317" alt="image" src="https://github.com/user-attachments/assets/bf573a7e-7005-4b25-8c9a-7e3f700513d5" /> | <img width="579" height="456" alt="image" src="https://github.com/user-attachments/assets/a22ed371-c22b-4aed-82c6-24483a9dc97f" /> |
| Centering fixes | <img width="3789" height="1612" alt="image" src="https://github.com/user-attachments/assets/dc9d707d-b3b4-4fe8-bb20-984ea2a220c7" /> | <img width="3829" height="1578" alt="image" src="https://github.com/user-attachments/assets/1924765a-44b2-46f5-869e-835d995026e7" /> |